### PR TITLE
Trim whitespace around search params before reloading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ window.handleSearchFormSubmit = function(e) {
     // For checkboxes/radios, only add if checked
     if ((el.type === 'checkbox' || el.type === 'radio') && !el.checked) return;
     if (el.value !== undefined && el.value !== null && el.value !== '') {
-      params.append(el.name, el.value);
+      params.append(el.name, el.value.trim());
     }
   });
   // Add backend and mode if present


### PR DESCRIPTION
Noticed that any accidental space before or after author's username fails the search. Added a simple .trim() to el.value. Not 100% sure if this breaks other parameters like user flairs etc because I'm unsure if Reddit strips whitespace the same way JS does.